### PR TITLE
Remove unnecessary bindAll use.

### DIFF
--- a/packages/rebound-runtime/lib/component.js
+++ b/packages/rebound-runtime/lib/component.js
@@ -19,7 +19,7 @@ var Component = Model.extend({
 
   constructor: function(options){
     options = options || (options = {});
-    _.bindAll(this, '_onModelChange', '_onCollectionChange', '__callOnComponent', '_notifySubtree');
+    _.bindAll(this, '__callOnComponent');
     this.cid = _.uniqueId('component');
     this.attributes = {};
     this.changed = {};


### PR DESCRIPTION
Resolves #29 

====

Summary:

`listenTo` binds the context automatically, so binding `_onModelChange` and `_onCollectionChange` isn't doing anything. `_notifySubtree` is always called directly, never as a callback, so again binding the context does nothing.

I've left `__callOnComponent`, as I'm not sure if it's called with the right context in all situations. I would guess that it is, though.