### PR TITLE
Added Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can include Rebound on your page like this:
 <script src="/javascripts/lib/rebound.runtime.js" id="Rebound">
 {
   "root": "/",
-  "globalComponents": {"chrome" : "nav"},
+  "services": {"chrome" : "nav"},
   "jsPrefix": "/javascripts/apps/:route/",
   "jsSuffix": "",
   "cssPrefix": "/stylesheets/apps/",
@@ -86,7 +86,7 @@ Because the Rebound script tag contains a src, nothing inside it gets executed, 
 ##### Config Options
 
  - __root__ - This is the equivelent to passing the ```root``` option to Backbone.history.start. If your application is not being served from the root url ```/``` of your domain, be sure to tell History where the root really is.
- - __globalComponents__ - By default, as will be talked about in the next section, there is only one page level component loaded at a time. The components specified here are for page elements you want to live the entire length of the user's session, like a global nav bar, footer, site-wide chat, etc. The object specifies ```{ "componentName": "cssSelector" }```. The output of the component will be loaded into the first matching element for the provided css selector on the page.
+ - __services__ - By default, as will be talked about in the next section, there is only one page level component loaded at a time. The components specified here are for page elements you want to live the entire length of the user's session, like a global nav bar, footer, site-wide chat, etc. The object specifies ```{ "componentName": "cssSelector" }```. The output of the component will be loaded into the first matching element for the provided css selector on the page.
  - __jsPrefix__ - Used by Rebound to construct the path to each page's js file. Use :route as a placeholder for the top level route's name (ex: /profile/1/activity is 'profile'). See routing for more details.
  - __jsSuffix__ - Used by Rebound to construct the path to each page's js file. Use :route as a placeholder for the top level route's name (ex: /profile/1/activity is 'profile'). See routing for more details.
  - __cssPrefix__ - Used by Rebound to construct the path to each page's css file. See routing for more details.
@@ -315,7 +315,7 @@ Your component's template is always rendered in the scope of your component. Tak
       /********* Default Properties ********/
       className: 'SomeClass',
       content: {
-        'first' : 'This Content', 
+        'first' : 'This Content',
         'last' : 'AWESOME!'
       }
       awesomeContent: function(){
@@ -326,7 +326,7 @@ Your component's template is always rendered in the scope of your component. Tak
       upgrade: function(event){
         this.set('content.last', 'SUPER AWESOME!!');
       }
-      
+
     })
   </script>
 </element>
@@ -337,7 +337,7 @@ It does exactly as you'd expect. The dom output of this element is:
 <example-element><div class="FirstClass SomeClass">This Content Is AWESOME!</div></example-element>
 ```
 
-You'll notice that, because of HTMLBars, we can simply write a variable, or "handlebar", anywhere in our template. It does not care if it is inside of an element, inside of a property, or even on the element itself! 
+You'll notice that, because of HTMLBars, we can simply write a variable, or "handlebar", anywhere in our template. It does not care if it is inside of an element, inside of a property, or even on the element itself!
 
 Also for free, all of these properties are automatically data bound to your property's data structure, no matter how deeply nested the data is. When the component method ```upgrade``` is run, ```content.last``` is updated and you would see the dom automatically update itself to:
 
@@ -358,7 +358,7 @@ This data nesting, data selection and data binding works with any mixture of obj
       /********* Default Properties ********/
 
       content: [{'bar': 'foo'}, {'biz': 'baz'}],
-      
+
       awesomeContent: function(){
         return this.get('content[0].bar');
       }
@@ -388,7 +388,7 @@ The ```{{on}}``` helper binds a component method to an element in your template 
 
 
 ##### if
-The ```{{#if}}``` helper has two forms. 
+The ```{{#if}}``` helper has two forms.
 
 Used as a block helper it looks like this:
 ```html
@@ -446,7 +446,7 @@ Inline:
 
 ##### with
 
-Sometimes you may want to invoke a section of your template with a different context. ```{{#with}}``` changes the context of the block you pass to it. 
+Sometimes you may want to invoke a section of your template with a different context. ```{{#with}}``` changes the context of the block you pass to it.
 
 ```html
 {{user.firstName}} {{user.lastName}}
@@ -457,9 +457,9 @@ Sometimes you may want to invoke a section of your template with a different con
 
 ##### partial
 
-The ```{{partial}}``` helper renders a registered partial. 
+The ```{{partial}}``` helper renders a registered partial.
 
-Unlike components, partials are templates with no functionality and are literally just a HTMLBars template. They can be a conveinent way of breaking up and organizing what may otherwise be a very large template. When rendered they inherit the context of its parent template. 
+Unlike components, partials are templates with no functionality and are literally just a HTMLBars template. They can be a conveinent way of breaking up and organizing what may otherwise be a very large template. When rendered they inherit the context of its parent template.
 
 The variable passed to this helper is the path to a .hbs template file on the server. When using the precompiler, Rebound will add a dependancy for the partial's template to the parent component / template so you don't need to worry about getting it on the page. Otherwise, the partial's template must be loaded on the page for it to appear. It is convention for partials to begin with an underscore. This underscore and the file extension are absent from the variable passed to the partial, so ```{{partial /public/demo/partial }}``` referances ```http://domain.com/public/demo/_partial.hbs```.
 
@@ -495,7 +495,7 @@ Your page level component:
   <script>
     return ({
       users: [
-        { 
+        {
           firstName: 'Adam',
           lastName: 'Miller'
         },{
@@ -529,7 +529,7 @@ The above example is very simple, but your new component can have all of the bel
 
 Rebound knows that home-page requires user-card because of the ```<link href="/public/components/user-card.html">``` in its template. When Rebound sees this link tag it will will add user-card to home-page's dependancies list.
 
-By default, child components inherit no scope from their parent components. You can pass in attributes by adding them right on to the tag, as the above example does with ```{{firstName}}``` and ```{{lastName}}```. And the values passed in are not limited to primitives! Any object, array or combination of the two can also be passed in to components. 
+By default, child components inherit no scope from their parent components. You can pass in attributes by adding them right on to the tag, as the above example does with ```{{firstName}}``` and ```{{lastName}}```. And the values passed in are not limited to primitives! Any object, array or combination of the two can also be passed in to components.
 
 Attributes passed in on the tag will override any values set in the component declaration. So, the above code will render:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reboundjs",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "Automatic data binding for Backbone using HTMLBars.",
   "main": "dist/cjs/rebound-precompiler/rebound-precompiler.js",
   "scripts": {

--- a/packages/rebound-component/lib/component.js
+++ b/packages/rebound-component/lib/component.js
@@ -64,6 +64,7 @@ function hydrate(spec, options){
 var Component = Model.extend({
 
   isComponent: true,
+  consumers: [],
 
   _callOnComponent: function(name, event){
     if(!_.isFunction(this[name])){ throw "ERROR: No method named " + name + " on component " + this.__name + "!"; }
@@ -71,7 +72,8 @@ var Component = Model.extend({
   },
 
   _listenToService: function(key, service){
-    this.listenTo(service, 'all', (type, model) => {
+    var self = this;
+    this.listenTo(service, 'all', (type, model, value, options) => {
       var attr,
           path = model.__path(),
           changed;
@@ -79,13 +81,43 @@ var Component = Model.extend({
         changed = model.changedAttributes();
         for(attr in changed){
           // TODO: Modifying arguments array is bad. change this
-          arguments[0] = ('change:' + key + '.' + path + (path && '.') + attr); // jshint ignore:line
-          this.trigger.apply(this, arguments);
+          type = ('change:' + key + '.' + path + (path && '.') + attr); // jshint ignore:line
+          options.service = key;
+          this.trigger.call(this, type, model, value, options);
         }
         return;
       }
-      return this.trigger.apply(this, arguments);
+      return this.trigger.call(this, type, model, value, options);
     });
+  },
+
+  // Set is overridden on components to accept components as a valid input type.
+  // Components set on other Components are mixed in as a shared object. {raw: true}
+  // It also marks itself as a consumer of this component
+  set: function(key, val, options){
+    var attrs, attr, serviceOptions;
+    if (typeof key === 'object') {
+      attrs = (key.isModel) ? key.attributes : key;
+      options = val;
+    } else (attrs = {})[key] = val;
+    options || (options = {});
+
+    // If reset option passed, do a reset. If nothing passed, return.
+    if(options.reset === true) return this.reset(attrs, options);
+    if(options.defaults === true) this.defaults = attrs;
+    if(_.isEmpty(attrs)) return;
+
+    // For each attribute passed:
+    for(key in attrs){
+      attr = attrs[key];
+      if(attr && attr.isComponent){
+        serviceOptions || (serviceOptions = _.defaults(_.clone(options), {raw: true}));
+        attr.consumers.push({key: key, component: this});
+        Rebound.Model.prototype.set.call(this, key, attr, serviceOptions);
+      }
+      Rebound.Model.prototype.set.call(this, key, attr, options);
+    }
+    return this;
   },
 
   constructor: function(options){
@@ -106,8 +138,10 @@ var Component = Model.extend({
     // In the model, primatives (arrays, objects, etc) are converted to Backbone Objects
     // Functions are compiled to find their dependancies and added as computed properties
     // Set our component's context with the passed data merged with the component's defaults
-    this.set((this.defaults || {}), {defaults: true});
+    this.set((this.defaults || {}));
     this.set((options.data || {}));
+
+    if(this.serviceName) Rebound.services[this.serviceName] = this;
 
     // Call on component is used by the {{on}} helper to call all event callbacks in the scope of the component
     this.helpers._callOnComponent = this._callOnComponent;
@@ -192,7 +226,7 @@ var Component = Model.extend({
     model || (model = {});
     collection || (collection = {});
     options || (options = {});
-    !collection.isData && (options = collection) && (collection = model);
+    !collection.isData && (type.indexOf('change:') === -1) && (options = collection) && (collection = model);
     this._toRender || (this._toRender = []);
 
     if( (type === 'reset' && options.previousAttributes) || type.indexOf('change:') !== -1){
@@ -219,6 +253,8 @@ var Component = Model.extend({
     };
     var context = this;
     var basePath = data.__path();
+    // If this event came from within a service, include the service key in the base path
+    if(options.service) basePath = options.service + '.' + basePath;
     var parts = $.splitPath(basePath);
     var key, obsPath, path, observers;
 
@@ -267,13 +303,27 @@ Component.extend= function(protoProps, staticProps) {
   protoProps.defaults = {};
   staticProps.services = {};
 
+  // If given a constructor, use it, otherwise use the default one defined above
+  if (protoProps && _.has(protoProps, 'constructor')) {
+    child = protoProps.constructor;
+  } else {
+    child = function(){ return parent.apply(this, arguments); };
+  }
+
+  // Our class should inherit everything from its parent, defined above
+  var Surrogate = function(){ this.constructor = child; };
+  Surrogate.prototype = parent.prototype;
+  child.prototype = new Surrogate();
+
   // For each property passed into our component base class
   _.each(protoProps, function(value, key, protoProps){
 
     // If a configuration property, ignore it
     if(configProperties[key]){ return; }
 
-    if(value.isComponent) staticProps.services[key] = value;
+    if(value && value.isService) value.consumers.push({component: child.prototype, key: key});
+
+    if(value && value.isComponent) staticProps.services[key] = value;
 
     // If a primative or backbone type object, or computed property (function which takes no arguments and returns a value) move it to our defaults
     if(!_.isFunction(value) || value.isModel || value.isComponent || (_.isFunction(value) && value.length === 0 && value.toString().indexOf('return') > -1)){
@@ -287,18 +337,6 @@ Component.extend= function(protoProps, staticProps) {
     // All other values are component methods, leave them be unless already defined.
 
   }, this);
-
-  // If given a constructor, use it, otherwise use the default one defined above
-  if (protoProps && _.has(protoProps, 'constructor')) {
-    child = protoProps.constructor;
-  } else {
-    child = function(){ return parent.apply(this, arguments); };
-  }
-
-  // Our class should inherit everything from its parent, defined above
-  var Surrogate = function(){ this.constructor = child; };
-  Surrogate.prototype = parent.prototype;
-  child.prototype = new Surrogate();
 
   // Extend our prototype with any remaining protoProps, overriting pre-defined ones
   if (protoProps){ _.extend(child.prototype, protoProps, staticProps); }

--- a/packages/rebound-component/lib/component.js
+++ b/packages/rebound-component/lib/component.js
@@ -321,8 +321,6 @@ Component.extend= function(protoProps, staticProps) {
     // If a configuration property, ignore it
     if(configProperties[key]){ return; }
 
-    if(value && value.isService) value.consumers.push({component: child.prototype, key: key});
-
     if(value && value.isComponent) staticProps.services[key] = value;
 
     // If a primative or backbone type object, or computed property (function which takes no arguments and returns a value) move it to our defaults

--- a/packages/rebound-component/lib/helpers.js
+++ b/packages/rebound-component/lib/helpers.js
@@ -99,8 +99,8 @@ helpers.if = function(params, hash, options, env){
 
   var condition = params[0];
 
-  if(condition === undefined){
-    return null;
+  if(condition === undefined || condition === null){
+    condition = false;
   }
 
   if(condition.isModel){
@@ -143,8 +143,8 @@ helpers.if = function(params, hash, options, env){
 helpers.unless = function(params, hash, options, env){
   var condition = params[0];
 
-  if(condition === undefined){
-    return null;
+  if(condition === undefined || condition === null){
+    condition = false;
   }
 
   if(condition.isModel){

--- a/packages/rebound-component/test/rebound_services_test.js
+++ b/packages/rebound-component/test/rebound_services_test.js
@@ -123,6 +123,11 @@ require(['rebound-component/component', 'simple-html-tokenizer', 'rebound-compil
       equal(service2.get('foo'), instance1.get('service2.foo'), 'A component can inherit from multiple services.');
       equal(service2.get('foo'), instance2.get('service2.foo'), 'Multiple components can inherit from multiple shared services.');
 
+      instance2.deinitialize();
+
+      equal(instance1.get('service2.foo'), 'bar', 'Services continue to persist even after consuming object deinitialization.');
+
+
     });
 
 

--- a/packages/rebound-data/lib/computed-property.js
+++ b/packages/rebound-data/lib/computed-property.js
@@ -241,7 +241,7 @@ _.extend(ComputedProperty.prototype, Backbone.Events, {
 
     if(!this.isChanging) return;
 
-    this.stopListening(value, 'all', this.onModify);
+    if(this.returnType !== 'value') this.stopListening(value, 'all', this.onModify);
 
     result = this.func.apply(context, params);
 
@@ -290,6 +290,7 @@ _.extend(ComputedProperty.prototype, Backbone.Events, {
     object._cid || (object._cid = object.cid);
     target.cid = object.cid;
     this.tracking = object;
+    console.log('TARGET:', target);
     this.listenTo(target, 'all', this.onModify);
   },
 

--- a/packages/rebound-data/lib/computed-property.js
+++ b/packages/rebound-data/lib/computed-property.js
@@ -198,6 +198,19 @@ _.extend(ComputedProperty.prototype, Backbone.Events, {
     context.off('all', this.onRecompute).on('all', this.onRecompute);
   },
 
+  unwire: function(){
+    var root = this.__root__;
+    var context = this.__parent__;
+
+    _.each(this.deps, function(path){
+      var dep = root.get(path, {raw: true});
+      if(!dep || !dep.isComputedProperty) return;
+      dep.off('dirty', this.markDirty);
+    }, this);
+
+    context.off('all', this.onRecompute);
+  },
+
   // Call this computed property like you would with Function.call()
   call: function(){
     var args = Array.prototype.slice.call(arguments),
@@ -215,13 +228,13 @@ _.extend(ComputedProperty.prototype, Backbone.Events, {
   // the original object and return the value.
   apply: function(context, params){
 
-    if(!this.isDirty || this.isChanging) return;
+    context || (context = this.__parent__);
+
+    if(!this.isDirty || this.isChanging || !context) return;
     this.isChanging = true;
 
     var value = this.cache[this.returnType],
         result;
-
-    context || (context = this.__parent__);
 
     // Check all of our dependancies to see if they are evaluating.
     // If we have a dependancy that is dirty and this isnt its first run,
@@ -290,7 +303,6 @@ _.extend(ComputedProperty.prototype, Backbone.Events, {
     object._cid || (object._cid = object.cid);
     target.cid = object.cid;
     this.tracking = object;
-    console.log('TARGET:', target);
     this.listenTo(target, 'all', this.onModify);
   },
 

--- a/packages/rebound-data/lib/rebound-data.js
+++ b/packages/rebound-data/lib/rebound-data.js
@@ -75,6 +75,7 @@ var sharedMethods = {
     if (this.undelegateEvents) this.undelegateEvents();
     if (this.stopListening) this.stopListening();
     if (this.off) this.off();
+    if (this.unwire) this.unwire();
 
   // Destroy this data object's lineage
     delete this.__parent__;
@@ -107,11 +108,13 @@ var sharedMethods = {
   // Destroy all children of this data object.
   // If a Collection, de-init all of its Models, if a Model, de-init all of its
   // Attributes, if a Computed Property, de-init its Cache objects.
-    _.each(this.models, function (val) { val && val.deinitialize && val.deinitialize(); });
-    _.each(this.attributes, function (val) { val && val.deinitialize && val.deinitialize();});
-    this.cache && this.cache.collection.deinitialize();
-    this.cache && this.cache.model.deinitialize();
-
+    _.each(this.models, function(val){ val && val.deinitialize && val.deinitialize(); });
+    this.models && (this.models.length = 0);
+    _.each(this.attributes, (val, key) => { delete this.attributes[key]; val && val.deinitialize && val.deinitialize(); });
+    if(this.cache){
+      this.cache.collection.deinitialize();
+      this.cache.model.deinitialize();
+    }
   }
 };
 

--- a/packages/rebound-router/lib/rebound-router.js
+++ b/packages/rebound-router/lib/rebound-router.js
@@ -272,7 +272,7 @@ if(!window.Backbone){ throw "Backbone must be on the page for Rebound to load.";
       Rebound.services.page = new LazyComponent();
 
       // Install our global components
-      _.each(this.config.globalComponents, function(selector, route){
+      _.each(this.config.services, function(selector, route){
         Rebound.services[route] = new LazyComponent();
         fetchResources.call(router, route, route, selector);
       });

--- a/packages/rebound-router/lib/rebound-router.js
+++ b/packages/rebound-router/lib/rebound-router.js
@@ -62,11 +62,11 @@ if(!window.Backbone){ throw "Backbone must be on the page for Rebound to load.";
       router.route(key, value, this[routeFunctionName]);
     }, this);
 
-    if(!isGlobal){
-      window.Rebound.services.page = (this.current = pageInstance).__component__;
-    } else{
-      window.Rebound.services[pageInstance.__name] = pageInstance.__component__;
-    }
+    var name = (isGlobal) ? primaryRoute : 'page';
+    if(!isGlobal) this.current = pageInstance;
+    if(window.Rebound.services[name].isService)
+      window.Rebound.services[name].hydrate(pageInstance.__component__);
+    window.Rebound.services[name] = pageInstance.__component__;
 
     // Return our newly installed app
     return pageInstance;
@@ -148,7 +148,7 @@ if(!window.Backbone){ throw "Backbone must be on the page for Rebound to load.";
       }
       else{
         // AMD Will Manage Dependancies For Us. Load The App.
-        window.require([jsUrl], function(PageClass){
+        return window.require([jsUrl], function(PageClass){
 
           if((jsLoaded = true) && (PageApp = PageClass) && cssLoaded){
 
@@ -168,6 +168,37 @@ if(!window.Backbone){ throw "Backbone must be on the page for Rebound to load.";
         });
       }
 
+  }
+
+  // Services and keep track of their consumers. LazyServices are placeholders
+  // for services that haven't loaded yet. A LazyComponent mimics the api of a
+  // real service/component (they are the same), and when the service finally
+  // loads, its ```hydrate``` method is called. All consumers of the service will
+  // have the now fully loaded service set, the LazyService will transfer all of
+  // its consumers over to the fully loaded service, and then destroy itself.
+  function LazyComponent(){
+    this.isService = true;
+    this.isComponent = true;
+    this.isModel = true;
+    this.attributes = {};
+    this.consumers = [];
+    this.set = this.on = this.off = function(){
+      return 1;
+    };
+    this.get = function(path){
+      return (path) ? undefined : this;
+    };
+    this.hydrate = function(service){
+      _.each(this.consumers, function(consumer){
+        var component = consumer.component,
+            key = consumer.key;
+        if(component.attributes && component.set) component.set(key, service);
+        if(component.services) component.services[key] = service;
+        if(component.defaults) component.defaults[key] = service;
+      });
+      service.consumers = this.consumers;
+      delete this.consumers;
+    }
   }
 
   // ReboundRouter Constructor
@@ -213,8 +244,7 @@ if(!window.Backbone){ throw "Backbone must be on the page for Rebound to load.";
       this.config.handlers = [];
 
       var remoteUrl = /^([a-z]+:)|^(\/\/)|^([^\/]+\.)/,
-
-      router = this;
+          router = this;
 
       // Convert our routeMappings to regexps and push to our handlers
       _.each(this.config.routeMapping, function(value, route){
@@ -239,8 +269,11 @@ if(!window.Backbone){ throw "Backbone must be on the page for Rebound to load.";
         $(document).markLinks();
       });
 
+      Rebound.services.page = new LazyComponent();
+
       // Install our global components
       _.each(this.config.globalComponents, function(selector, route){
+        Rebound.services[route] = new LazyComponent();
         fetchResources.call(router, route, route, selector);
       });
 

--- a/packages/rebound-router/lib/rebound-router.js
+++ b/packages/rebound-router/lib/rebound-router.js
@@ -170,7 +170,7 @@ if(!window.Backbone){ throw "Backbone must be on the page for Rebound to load.";
 
   }
 
-  // Services and keep track of their consumers. LazyServices are placeholders
+  // Services keep track of their consumers. LazyComponent are placeholders
   // for services that haven't loaded yet. A LazyComponent mimics the api of a
   // real service/component (they are the same), and when the service finally
   // loads, its ```hydrate``` method is called. All consumers of the service will

--- a/test/demo/index.html
+++ b/test/demo/index.html
@@ -5,7 +5,7 @@
     <script src="../../dist/rebound.runtime.js" id="Rebound" async>
     {
       "root": "/test/demo",
-      "globalComponents": {"service" : "nav"},
+      "services": {"service" : "nav"},
       "jsPath": "/test/demo/templates/:app.js",
       "cssPath": "/test/demo/:app.css",
       "triggerOnFirstLoad": false,


### PR DESCRIPTION
Components, when passed another component, will consume it as a service. 

This service, unlike normal models, can be shared across many data trees. It serves as a type of global state - when one data tree modifies the service, it reflects the changes in all other data trees that consume it. 

The Rebound config globalComponents setting has been re-named to services. Any services specified here will be loaded by the router and live globally in Rebound.services[key]. These services can be mixed in to component definitions.

The Router now has a LazyComponent object that serves as a placeholder for all services that are specified in the config object (renamed from globalComponents). The LazyComponent allows the page's models to be instantiated, even if a service that is consuming hasn't been created or loaded yet, and hydrate its consumers with the actual data once the service has successfully loaded – aka, asynchronous service loading. 

Fixed a bug in computed properties where if a computed property returns an array as a value, backbone fails when it tries to unbind its events. Computed properties now unbind properly from its defendants on deinit.